### PR TITLE
Remove unsupported db options from mongo connection

### DIFF
--- a/spec/GridFSBucketStorageAdapter.spec.js
+++ b/spec/GridFSBucketStorageAdapter.spec.js
@@ -24,9 +24,10 @@ describe_only_db('mongo')('GridFSBucket', () => {
     const databaseURI = 'mongodb://localhost:27017/parse';
     const gfsAdapter = new GridFSBucketAdapter(databaseURI, {
       retryWrites: true,
-      // these are not supported by mongo
+      // these are not supported by the mongo client
       enableSchemaHooks: true,
       schemaCacheTtl: 5000,
+      maxTimeMS: 30000,
     });
 
     const db = await gfsAdapter._connect();

--- a/spec/GridFSBucketStorageAdapter.spec.js
+++ b/spec/GridFSBucketStorageAdapter.spec.js
@@ -20,6 +20,25 @@ describe_only_db('mongo')('GridFSBucket', () => {
     await db.dropDatabase();
   });
 
+  it('should connect to mongo with the supported database options', async () => {
+    const databaseURI = 'mongodb://localhost:27017/parse';
+    const gfsAdapter = new GridFSBucketAdapter(databaseURI, {
+      retryWrites: true,
+      // these are not supported by mongo
+      enableSchemaHooks: true,
+      schemaCacheTtl: 5000,
+    });
+
+    const db = await gfsAdapter._connect();
+    const status = await db.admin().serverStatus();
+
+    // connection will fail if unsupported keys are
+    // passed into the mongo connection options
+    expect(status.connections.current > 0).toEqual(true);
+
+    expect(db.options?.retryWrites).toEqual(true);
+  });
+
   it('should save an encrypted file that can only be decrypted by a GridFS adapter with the encryptionKey', async () => {
     const unencryptedAdapter = new GridFSBucketAdapter(databaseURI);
     const encryptedAdapter = new GridFSBucketAdapter(

--- a/src/Adapters/Files/GridFSBucketAdapter.js
+++ b/src/Adapters/Files/GridFSBucketAdapter.js
@@ -35,7 +35,7 @@ export class GridFSBucketAdapter extends FilesAdapter {
       useUnifiedTopology: true,
     };
     const mongoOptions = { ...databaseOptions };
-    for (const key of ['enableSchemaHooks', 'schemaCacheTtl']) {
+    for (const key of ['enableSchemaHooks', 'schemaCacheTtl', 'maxTimeMS']) {
       delete mongoOptions[key];
     }
     this._mongoOptions = Object.assign(defaultMongoOptions, mongoOptions);

--- a/src/Adapters/Files/GridFSBucketAdapter.js
+++ b/src/Adapters/Files/GridFSBucketAdapter.js
@@ -20,7 +20,7 @@ export class GridFSBucketAdapter extends FilesAdapter {
 
   constructor(
     mongoDatabaseURI = defaults.DefaultMongoURI,
-    mongoOptions = {},
+    databaseOptions = {},
     encryptionKey = undefined
   ) {
     super();
@@ -34,6 +34,10 @@ export class GridFSBucketAdapter extends FilesAdapter {
       useNewUrlParser: true,
       useUnifiedTopology: true,
     };
+    const mongoOptions = { ...databaseOptions };
+    for (const key of ['enableSchemaHooks', 'schemaCacheTtl']) {
+      delete mongoOptions[key];
+    }
     this._mongoOptions = Object.assign(defaultMongoOptions, mongoOptions);
   }
 


### PR DESCRIPTION
A new set of Parse Config options were added in v6 to `databaseOptions` called [enableSchemaHooks](https://github.com/parse-community/parse-server/pull/7214) and [schemaCacheTtl](https://github.com/parse-community/parse-server/pull/8436). However, these options are not strictly speaking _database options_, they instead manage Parse's internal behaviour with relation to the database. This means that MongoDB doesn't recognise these options and so, they must not be passed into the MongoDB client constructor.

This was correctly handled in the MongoStorageAdapter where the new, [non-mongodb options are deleted - Screenshot 1](https://github.com/parse-community/parse-server/blob/alpha/src/Adapters/Storage/Mongo/MongoStorageAdapter.js#L159)  before they're used as MongoDB client options.

However, there remains another area where the unsupported options are passed to a MongoDB client. You can see in Screenshot 2 that `_mongoOptions` is used directly when connecting to the MongoDB client in the GridFSBucketAdapter.
This is where an error is thrown (screenshots 3 and 4) if a Parse Server uses the new `enableSchemaHooks` or `schemaCacheTtl` options.

Screenshot 1
![image](https://user-images.githubusercontent.com/5912209/223688496-86b2a912-b0fd-471e-b62d-94ebf3ed9044.png)

Screenshot 2
![image](https://user-images.githubusercontent.com/5912209/223688682-8d619256-a319-49b9-86d7-fe7c56b1deb6.png)

Screenshot 3
![image](https://user-images.githubusercontent.com/5912209/223688707-0f8a05fb-b1d3-47ad-ad91-d901d71d0ea2.png)

Screenshot 4
![image](https://user-images.githubusercontent.com/5912209/223688743-7f1188c4-23a6-4fd1-8607-2452e151e28f.png)
